### PR TITLE
[feature] Separate items in results with newline

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -35,11 +35,11 @@ else if ($exist:resource eq 'execute') then
     let $query := request:get-parameter("qu", ())
     let $base := request:get-parameter("base", ())
     let $output := request:get-parameter("output", ())
-    let $startTime := util:system-time()
     return
         switch ($output)
             case "adaptive"
             case "json"
+            case "text"
             case "xml" return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
                     <!-- Query is executed by XQueryServlet -->
@@ -49,7 +49,7 @@ else if ($exist:resource eq 'execute') then
                         <set-attribute name="xquery.source" value="{$query}"/>
                         <!-- Results should be written into attribute 'results' -->
                         <set-attribute name="xquery.attribute" value="results"/>
-        		        <set-attribute name="xquery.module-load-path" value="{$base}"/>
+                        <set-attribute name="xquery.module-load-path" value="{$base}"/>
                         <clear-attribute name="results"/>
                         <!-- Errors should be passed through instead of terminating the request -->
                         <set-attribute name="xquery.report-errors" value="no"/>
@@ -61,10 +61,8 @@ else if ($exist:resource eq 'execute') then
                         <forward url="results.xql">
                            <clear-attribute name="xquery.source"/>
                            <clear-attribute name="xquery.attribute"/>
-                           <set-attribute name="elapsed"
-                               value="{string(seconds-from-duration(util:system-time() - $startTime))}"/>
                         </forward>
-        	        </view>
+                    </view>
                 </dispatch>
             default return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -73,7 +71,7 @@ else if ($exist:resource eq 'execute') then
                         <set-header name="Cache-Control" value="no-cache"/>
                         <!-- Query is passed via the attribute 'xquery.source' -->
                         <set-attribute name="xquery.source" value="{$query}"/>
-            	        <set-attribute name="xquery.module-load-path" value="{$base}"/>
+                        <set-attribute name="xquery.module-load-path" value="{$base}"/>
                         <!-- Errors should be passed through instead of terminating the request -->
                         <set-attribute name="xquery.report-errors" value="yes"/>
                         <set-attribute name="start-time" value="{util:system-time()}"/>


### PR DESCRIPTION
- Closes https://github.com/eXist-db/atom-existdb/issues/57
- Prepares results API for atom plugin to specify different serialization methods (though the plugin remains hard coded to request adaptive)
- Also, remove unused “elapsed” attribute from controller.xql and “$input” from results.xql, and replace tabs with spaces